### PR TITLE
Add persistent calc layers

### DIFF
--- a/src/kinyu/calc_graph/__init__.py
+++ b/src/kinyu/calc_graph/__init__.py
@@ -1,2 +1,2 @@
 # This file will expose the public API of the calc_graph module.
-from .graph import calc_node, calc_context
+from .graph import calc_node, calc_context, calc_layer


### PR DESCRIPTION
## Summary
- add a reusable `calc_layer` context manager that keeps overrides and cache state across entries
- expose the new layer helper through the public API and guard the internal registry
- expand the calc graph tests to cover persistent layers, named reuse, and independent layer overrides

## Testing
- PYTHONPATH=src pytest src/kinyu/calc_graph/tests/test_calc_graph.py

------
https://chatgpt.com/codex/tasks/task_e_68d8fa79cd848321b6f7f50ed75952f2