### PR TITLE
Link to WASM demo instructions from module README

### DIFF
--- a/src/kinyu/warrants/README.md
+++ b/src/kinyu/warrants/README.md
@@ -4,7 +4,10 @@ This document explains how `price_exotic_warrant` in `src/lib.rs` prices a calla
 warrant whose strike is reset weekly at a discount to the spot price and that is
 subject to issuer buybacks and default risk. The pricing engine combines
 correlated equity/credit Monte Carlo simulation with Longstaff–Schwartz least
-squares regression to approximate the continuation value of the security.
+squares regression to approximate the continuation value of the security. A live
+web demonstration of the pricing workflow is also available; see the
+accompanying [WASM_DEMO_README.md](WASM_DEMO_README.md) for details on building and publishing the
+WebAssembly demo alongside this module.
 
 ## Model Inputs
 

--- a/src/kinyu/warrants/WASM_DEMO_README.md
+++ b/src/kinyu/warrants/WASM_DEMO_README.md
@@ -31,6 +31,22 @@ If you have another HTTP server available (like `python -m http.server`, Node.js
 
 **Important**: WebAssembly modules require proper MIME types and CORS headers, so make sure your server is configured correctly.
 
+## Publishing the Demo to GitHub Pages
+
+To make the live demo available at
+`https://tayglobal.github.io/kinyu-demo/demo/warrant`, copy the HTML shell and
+the generated WebAssembly assets into the repository's `docs/` folder before
+pushing to the default branch:
+
+```bash
+mkdir -p docs/demo/warrant/pkg
+cp src/kinyu/warrants/warrants_demo.html docs/demo/warrant/index.html
+cp src/kinyu/warrants/pkg/* docs/demo/warrant/pkg/
+```
+
+Running these commands after building the WebAssembly package keeps the GitHub
+Pages site in sync with the latest demo build.
+
 ## Building from Source
 
 If you need to rebuild the WebAssembly module:


### PR DESCRIPTION
## Summary
- update the module README to link directly to the WASM demo instructions for publishing guidance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9e4b1d1688321864dd955b1f14043