### PR TITLE
Fix warrant quota dynamics and refresh Python demo

### DIFF
--- a/src/kinyu/floating_strike_warrant/Cargo.toml
+++ b/src/kinyu/floating_strike_warrant/Cargo.toml
@@ -5,7 +5,16 @@ edition = "2024"
 description = "LSMC pricing engine for floating strike warrants with reset and exercise limits"
 license = "MIT OR Apache-2.0"
 
+[lib]
+name = "floating_strike_warrant"
+crate-type = ["lib", "cdylib"]
+
 [dependencies]
 rand = { version = "0.8", features = ["std"] }
 rand_distr = "0.4"
 nalgebra = { version = "0.32", features = ["std"] }
+pyo3 = { version = "0.21", optional = true }
+
+[features]
+default = []
+python = ["dep:pyo3", "pyo3/extension-module"]

--- a/src/kinyu/floating_strike_warrant/README.md
+++ b/src/kinyu/floating_strike_warrant/README.md
@@ -96,6 +96,38 @@ cargo test
 
 Both commands should finish without failures and validate the pricing routines, path mechanics, and stress scenarios described above.
 
+## Python Binding Demo
+
+The crate exposes an optional [PyO3](https://pyo3.rs/) binding (behind the `python` feature flag) that makes the Monte Carlo pricer available from Python. A minimal end-to-end workflow is:
+
+```bash
+cd /workspace/kinyu-demo/src/kinyu/floating_strike_warrant
+python -m venv .venv
+source .venv/bin/activate
+pip install maturin
+maturin build --release --features python
+pip install target/wheels/floating_strike_warrant-*.whl
+python python_demo.py
+```
+
+The `python_demo.py` script calls the Rust pricer for a baseline set of parameters and several perturbations to illustrate how the value reacts to key risk drivers. Because the pricer now tracks inventory depletion and quota refills explicitly, changes to volatility, interest rates, and the issuer buyback cap all propagate through the valuation. Running the script produces a Markdown table such as the one below (generated with 3,000 Monte Carlo paths per scenario and a fixed RNG seed):
+
+| Scenario | Key value | Price |
+| --- | --- | --- |
+| Baseline | - | 2.513525 |
+| Spot -5% | 95.0000 | 2.387849 |
+| Spot +5% | 105.0000 | 2.639201 |
+| Volatility 15% | 0.1500 | 2.510979 |
+| Volatility 35% | 0.3500 | 2.551016 |
+| Rate 0% | 0.0000 | 2.506402 |
+| Rate 4% | 0.0400 | 2.520646 |
+| Buyback 2 | 2.0000 | 1.820391 |
+| Buyback 3 | 3.0000 | 2.296211 |
+| Discount 85% | 0.8500 | 3.759237 |
+| Discount 95% | 0.9500 | 1.314383 |
+| Quota 10% | 0.1000 | 1.009646 |
+| Quota 40% | 0.4000 | 1.997013 |
+
 ## Further Reading
 
 For more background on LSMC pricing of American-style derivatives, see Longstaff & Schwartz (2001).

--- a/src/kinyu/floating_strike_warrant/python_demo.py
+++ b/src/kinyu/floating_strike_warrant/python_demo.py
@@ -1,0 +1,78 @@
+"""Demonstration of the floating-strike warrant Python binding."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import floating_strike_warrant as fsw
+
+
+@dataclass(frozen=True)
+class Scenario:
+    label: str
+    focus: Optional[str]
+    updates: Dict[str, Any]
+
+
+BASELINE: Dict[str, Any] = {
+    "initial_price": 100.0,
+    "risk_free_rate": 0.02,
+    "volatility": 0.25,
+    "maturity": 1.0,
+    "steps_per_year": 252,
+    "strike_discount": 0.9,
+    "strike_reset_steps": 5,
+    "buyback_price": 25.0,
+    "exercise_limit_fraction": 0.25,
+    "exercise_limit_period_steps": 21,
+    "next_limit_reset_step": 0,
+    "exercised_fraction_current_period": 0.0,
+    "num_paths": 3000,
+    "seed": 7,
+}
+
+
+SCENARIOS = [
+    Scenario("Baseline", None, {}),
+    Scenario("Spot -5%", "Spot", {"initial_price": BASELINE["initial_price"] * 0.95}),
+    Scenario("Spot +5%", "Spot", {"initial_price": BASELINE["initial_price"] * 1.05}),
+    Scenario("Volatility 15%", "Volatility", {"volatility": 0.15}),
+    Scenario("Volatility 35%", "Volatility", {"volatility": 0.35}),
+    Scenario("Rate 0%", "Rate", {"risk_free_rate": 0.0}),
+    Scenario("Rate 4%", "Rate", {"risk_free_rate": 0.04}),
+    Scenario("Buyback 2", "Buyback", {"buyback_price": 2.0}),
+    Scenario("Buyback 3", "Buyback", {"buyback_price": 3.0}),
+    Scenario("Discount 85%", "Discount", {"strike_discount": 0.85}),
+    Scenario("Discount 95%", "Discount", {"strike_discount": 0.95}),
+    Scenario("Quota 10%", "Quota", {"exercise_limit_fraction": 0.10}),
+    Scenario("Quota 40%", "Quota", {"exercise_limit_fraction": 0.40}),
+]
+
+
+def main() -> None:
+    rows = []
+    for scenario in SCENARIOS:
+        params = {**BASELINE, **scenario.updates}
+        price = fsw.price_warrant_py(**params)
+        value = "-"
+        if scenario.focus is not None:
+            key_map = {
+                "Spot": "initial_price",
+                "Volatility": "volatility",
+                "Rate": "risk_free_rate",
+                "Buyback": "buyback_price",
+                "Discount": "strike_discount",
+                "Quota": "exercise_limit_fraction",
+            }
+            source_key = key_map[scenario.focus]
+            value = f"{params[source_key]:.4f}"
+        rows.append((scenario.label, value, price))
+
+    print("| Scenario | Key value | Price |")
+    print("| --- | --- | --- |")
+    for label, value, price in rows:
+        print(f"| {label} | {value} | {price:.6f} |")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- track quota inventory within the LSMC loop so volatility, rates, and buyback caps affect valuations
- update basis inputs and tests to cover the new state information and exercise logging
- refresh the Python demo scenarios and README sensitivity table to highlight the corrected behaviour

## Testing
- `cargo test`
- `python src/kinyu/floating_strike_warrant/python_demo.py`


------
https://chatgpt.com/codex/tasks/task_e_68db3e2d2cbc8321a30dce2a5326c4c4