### PR TITLE
Add holder put sensitivity to docs and Python demo

### DIFF
--- a/src/kinyu/floating_strike_warrant/README.md
+++ b/src/kinyu/floating_strike_warrant/README.md
@@ -1,6 +1,6 @@
 # Floating Strike Warrant Pricer
 
-This crate implements a Longstaff–Schwartz Monte Carlo (LSMC) pricer for a floating-strike warrant with periodic strike resets, issuer buybacks, and exercise quota limits.
+This crate implements a Longstaff–Schwartz Monte Carlo (LSMC) pricer for a floating-strike warrant with periodic strike resets, issuer buybacks, holder put protection, and exercise quota limits.
 
 ## Contract Overview
 
@@ -42,6 +42,16 @@ The issuer may call back the warrant at a buyback price $B$; the holder's value 
 
 $$
 V_t^{\text{post-call}} = \min\left(V_t^{\text{holder}}, B\right).
+$$
+
+When the underlying trades below a contractual trigger level $S^\text{put}$, the warrant holder can demand an early buyback at a guaranteed price $P^\text{put}$. This creates an additional cash flow opportunity that competes with the continuation and call choices in the valuation:
+
+$$
+\text{HolderPutPayoff}_t =
+\begin{cases}
+P^\text{put}, & S_t \leq S^\text{put}, \\
+0, & \text{otherwise}.
+\end{cases}
 $$
 
 ## Pricing Methodology
@@ -110,23 +120,27 @@ pip install target/wheels/floating_strike_warrant-*.whl
 python python_demo.py
 ```
 
-The `python_demo.py` script calls the Rust pricer for a baseline set of parameters and several perturbations to illustrate how the value reacts to key risk drivers. Because the pricer now tracks inventory depletion and quota refills explicitly, changes to volatility, interest rates, and the issuer buyback cap all propagate through the valuation. Running the script produces a Markdown table such as the one below (generated with 3,000 Monte Carlo paths per scenario and a fixed RNG seed):
+The `python_demo.py` script calls the Rust pricer for a baseline set of parameters and several perturbations to illustrate how the value reacts to key risk drivers. Because the pricer now tracks inventory depletion, quota refills, and the holder put option explicitly, changes to volatility, interest rates, the issuer buyback cap, and the put terms all propagate through the valuation. Running the script produces a Markdown table such as the one below (generated with 3,000 Monte Carlo paths per scenario and a fixed RNG seed):
 
 | Scenario | Key value | Price |
 | --- | --- | --- |
-| Baseline | - | 2.513525 |
-| Spot -5% | 95.0000 | 2.387849 |
-| Spot +5% | 105.0000 | 2.639201 |
-| Volatility 15% | 0.1500 | 2.510979 |
-| Volatility 35% | 0.3500 | 2.551016 |
-| Rate 0% | 0.0000 | 2.506402 |
-| Rate 4% | 0.0400 | 2.520646 |
-| Buyback 2 | 2.0000 | 1.820391 |
-| Buyback 3 | 3.0000 | 2.296211 |
-| Discount 85% | 0.8500 | 3.759237 |
-| Discount 95% | 0.9500 | 1.314383 |
-| Quota 10% | 0.1000 | 1.009535 |
-| Quota 40% | 0.4000 | 1.997013 |
+| Baseline | - | 3.139163 |
+| Spot -5% | 95.0000 | 3.253824 |
+| Spot +5% | 105.0000 | 3.091662 |
+| Volatility 15% | 0.1500 | 2.620668 |
+| Volatility 35% | 0.3500 | 3.665311 |
+| Rate 0% | 0.0000 | 3.242602 |
+| Rate 4% | 0.0400 | 3.061998 |
+| Buyback 2 | 2.0000 | 1.886489 |
+| Buyback 3 | 3.0000 | 2.515118 |
+| Discount 85% | 0.8500 | 4.220395 |
+| Discount 95% | 0.9500 | 2.096318 |
+| Quota 10% | 0.1000 | 2.007972 |
+| Quota 40% | 0.4000 | 2.621859 |
+| Put trigger 85 | 85.0000 | 3.694463 |
+| Put trigger 70 | 70.0000 | 2.912962 |
+| Put price 4 | 4.0000 | 2.825968 |
+| Put price 8 | 8.0000 | 3.452860 |
 
 ## Further Reading
 

--- a/src/kinyu/floating_strike_warrant/python_demo.py
+++ b/src/kinyu/floating_strike_warrant/python_demo.py
@@ -23,6 +23,8 @@ BASELINE: Dict[str, Any] = {
     "strike_discount": 0.9,
     "strike_reset_steps": 5,
     "buyback_price": 25.0,
+    "holder_put_trigger_price": 75.0,
+    "holder_put_price": 6.0,
     "exercise_limit_fraction": 0.25,
     "exercise_limit_period_steps": 21,
     "next_limit_reset_step": 0,
@@ -46,6 +48,26 @@ SCENARIOS = [
     Scenario("Discount 95%", "Discount", {"strike_discount": 0.95}),
     Scenario("Quota 10%", "Quota", {"exercise_limit_fraction": 0.10}),
     Scenario("Quota 40%", "Quota", {"exercise_limit_fraction": 0.40}),
+    Scenario(
+        "Put trigger 85",
+        "Put trigger",
+        {"holder_put_trigger_price": 85.0},
+    ),
+    Scenario(
+        "Put trigger 70",
+        "Put trigger",
+        {"holder_put_trigger_price": 70.0},
+    ),
+    Scenario(
+        "Put price 4",
+        "Put price",
+        {"holder_put_price": 4.0},
+    ),
+    Scenario(
+        "Put price 8",
+        "Put price",
+        {"holder_put_price": 8.0},
+    ),
 ]
 
 
@@ -63,6 +85,8 @@ def main() -> None:
                 "Buyback": "buyback_price",
                 "Discount": "strike_discount",
                 "Quota": "exercise_limit_fraction",
+                "Put trigger": "holder_put_trigger_price",
+                "Put price": "holder_put_price",
             }
             source_key = key_map[scenario.focus]
             value = f"{params[source_key]:.4f}"


### PR DESCRIPTION
## Summary
- extend the warrant parameters with holder put trigger and payoff inputs and expose them to the Python bindings
- incorporate the holder put logic in the LSMC pricing routine and ensure values honour the issuer buyback cap
- add regression tests covering the new holder put scenarios
- document the holder put feature and its sensitivity scenarios in the README and Python demo output

## Testing
- `cargo test --lib`
- `python python_demo.py`


------
https://chatgpt.com/codex/tasks/task_e_68dc6056cf448321906ae95ed3c94190