### PR TITLE
Add minimal MCP git client demo

### DIFF
--- a/src/kinyu/mcp/README.md
+++ b/src/kinyu/mcp/README.md
@@ -1,0 +1,31 @@
+# MCP Git Client Demo
+
+This package illustrates how to communicate with an MCP server using nothing
+but Python's standard library.  The example client launches
+[`mcp-server-git`](https://pypi.org/project/mcp-server-git/) through the
+configuration below and then drives the JSON-RPC handshake manually.
+
+```json
+{
+  "servers": {
+    "git": {
+      "command": "uvx",
+      "args": ["mcp-server-git"]
+    }
+  }
+}
+```
+
+Run the demo with::
+
+    PYTHONPATH=src python -m kinyu.mcp.git --repository /path/to/git/repo
+
+After establishing the connection it lists the available Git tools and invokes
+`git_status` by default. You can call a different tool by passing
+`--tool <name>` plus optional key/value pairs that will be converted into JSON
+arguments::
+
+    PYTHONPATH=src python -m kinyu.mcp.git --repository . --tool git_log --args max_count=5
+
+Because the implementation talks JSON-RPC directly over stdio it does not rely
+on the `mcp` Python package or any other third-party dependencies.

--- a/src/kinyu/mcp/README.md
+++ b/src/kinyu/mcp/README.md
@@ -1,9 +1,10 @@
-# MCP Git Client Demo
+# MCP Client Demo
 
 This package illustrates how to communicate with an MCP server using nothing
-but Python's standard library.  The example client launches
-[`mcp-server-git`](https://pypi.org/project/mcp-server-git/) through the
-configuration below and then drives the JSON-RPC handshake manually.
+but Python's standard library.  The reusable `MCPClient` can launch any
+server described in the configuration below and drive the JSON-RPC handshake
+manually.  The included CLI demonstrates the
+[`mcp-server-git`](https://pypi.org/project/mcp-server-git/) server.
 
 ```json
 {
@@ -16,11 +17,11 @@ configuration below and then drives the JSON-RPC handshake manually.
 }
 ```
 
-Run the demo with::
+Run the git-focused demo with::
 
     PYTHONPATH=src python -m kinyu.mcp.git --repository /path/to/git/repo
 
-After establishing the connection it lists the available Git tools and invokes
+After establishing the connection it lists the available tools and invokes
 `git_status` by default. You can call a different tool by passing
 `--tool <name>` plus optional key/value pairs that will be converted into JSON
 arguments::
@@ -28,4 +29,7 @@ arguments::
     PYTHONPATH=src python -m kinyu.mcp.git --repository . --tool git_log --args max_count=5
 
 Because the implementation talks JSON-RPC directly over stdio it does not rely
-on the `mcp` Python package or any other third-party dependencies.
+on the `mcp` Python package or any other third-party dependencies. To
+experiment with another server, add it to the configuration and pass its
+identifier via `--server-name`. Additional CLI arguments for the server can be
+provided with `--server-arg`.

--- a/src/kinyu/mcp/__init__.py
+++ b/src/kinyu/mcp/__init__.py
@@ -1,0 +1,8 @@
+"""Utilities for working with the Model Context Protocol (MCP).
+
+This subpackage intentionally keeps its dependencies limited to Python's
+standard library so it can be used in environments where additional MCP
+client libraries are unavailable.
+"""
+
+__all__ = ["git"]

--- a/src/kinyu/mcp/__init__.py
+++ b/src/kinyu/mcp/__init__.py
@@ -5,4 +5,6 @@ standard library so it can be used in environments where additional MCP
 client libraries are unavailable.
 """
 
-__all__ = ["git"]
+from .git import MCPClient, MCP_CONFIG  # noqa: F401
+
+__all__ = ["MCPClient", "MCP_CONFIG"]

--- a/src/kinyu/mcp/git.py
+++ b/src/kinyu/mcp/git.py
@@ -1,0 +1,373 @@
+"""Example MCP client that talks to ``mcp-server-git`` without third-party deps.
+
+The goal of this module is to demonstrate the minimum plumbing that a Python
+program needs in order to communicate with an MCP server using only the
+standard library.  It follows the JSON-RPC interface that the
+``mcp-server-git`` package exposes over stdio.
+
+Usage
+-----
+The module exposes a :func:`main` entrypoint so it can be executed directly::
+
+    python -m kinyu.mcp.git --repository /path/to/repository
+
+The script will:
+
+* launch ``mcp-server-git`` using the configuration described in the
+  ``MCP_CONFIG`` constant,
+* perform the JSON-RPC handshake (`initialize` followed by
+  ``notifications/initialized``),
+* list the Git-related tools that the server exposes, and
+* call ``git_status`` as a concrete example.
+
+Because the transport uses newline-delimited JSON, the implementation below
+just writes JSON payloads to the server's stdin and reads responses line by
+line from stdout.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import json
+import sys
+from asyncio.subprocess import Process
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+JsonDict = Dict[str, Any]
+
+MCP_CONFIG: JsonDict = {
+    "servers": {
+        "git": {
+            "command": "uvx",
+            "args": ["mcp-server-git"],
+        }
+    }
+}
+"""Model Context Protocol configuration for the git server."""
+
+
+@dataclass
+class PendingRequest:
+    """Bookkeeping container for in-flight JSON-RPC requests."""
+
+    future: asyncio.Future[JsonDict]
+
+
+@dataclass
+class MCPGitClient:
+    """Minimal asynchronous MCP client that talks to ``mcp-server-git``."""
+
+    repository: Path
+    config: JsonDict = field(default_factory=lambda: json.loads(json.dumps(MCP_CONFIG)))
+    _process: Process | None = field(default=None, init=False, repr=False)
+    _stdout_task: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
+    _stderr_task: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
+    _pending: Dict[int, PendingRequest] = field(default_factory=dict, init=False, repr=False)
+    _next_request_id: int = field(default=1, init=False, repr=False)
+    _loop: asyncio.AbstractEventLoop | None = field(default=None, init=False, repr=False)
+
+    async def __aenter__(self) -> "MCPGitClient":
+        await self._start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
+    async def _start(self) -> None:
+        """Launch the ``mcp-server-git`` subprocess and set up background tasks."""
+
+        server_cfg = self.config["servers"]["git"]
+        command = server_cfg["command"]
+        args = list(server_cfg.get("args", []))
+
+        # ``mcp-server-git`` accepts a ``--repository`` CLI argument.
+        args.extend(["--repository", str(self.repository)])
+
+        self._loop = asyncio.get_running_loop()
+
+        self._process = await asyncio.create_subprocess_exec(
+            command,
+            *args,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        assert self._process.stdout is not None
+        assert self._process.stderr is not None
+
+        self._stdout_task = asyncio.create_task(self._read_stdout(self._process.stdout))
+        self._stderr_task = asyncio.create_task(self._log_stderr(self._process.stderr))
+
+        await self._initialize()
+
+    async def close(self) -> None:
+        """Tear down the client and stop the subprocess."""
+
+        if self._process:
+            if self._process.stdin:
+                self._process.stdin.close()
+                with contextlib.suppress(Exception):
+                    await self._process.stdin.wait_closed()  # type: ignore[func-returns-value]
+
+            if self._process.returncode is None:
+                self._process.terminate()
+                with contextlib.suppress(ProcessLookupError):
+                    await self._process.wait()
+
+        if self._stdout_task:
+            self._stdout_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._stdout_task
+
+        if self._stderr_task:
+            self._stderr_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._stderr_task
+
+    async def _initialize(self) -> None:
+        """Perform the MCP initialization handshake."""
+
+        request_id = self._next_id()
+        initialize_request = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "kinyu-demo", "version": "0.1.0"},
+            },
+        }
+
+        await self._send_request(request_id, initialize_request)
+        await self._send_notification(
+            {
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized",
+                "params": {},
+            }
+        )
+
+    async def list_tools(self, cursor: str | None = None) -> JsonDict:
+        """Return the list of tools exposed by ``mcp-server-git``."""
+
+        request_id = self._next_id()
+        request = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "tools/list",
+            "params": {"cursor": cursor} if cursor is not None else {},
+        }
+
+        return await self._send_request(request_id, request)
+
+    async def call_tool(self, name: str, arguments: Optional[JsonDict] = None) -> JsonDict:
+        """Invoke a tool by name with the supplied arguments."""
+
+        request_id = self._next_id()
+        request = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "tools/call",
+            "params": {
+                "name": name,
+                "arguments": arguments or {},
+            },
+        }
+        return await self._send_request(request_id, request)
+
+    async def _send_request(self, request_id: int, payload: JsonDict) -> JsonDict:
+        assert self._process and self._process.stdin
+        assert self._loop is not None
+
+        future: asyncio.Future[JsonDict] = self._loop.create_future()
+        self._pending[request_id] = PendingRequest(future=future)
+
+        await self._write_json(payload)
+
+        response = await future
+
+        if "error" in response:
+            error = response["error"]
+            message = error.get("message", "Unknown MCP error")
+            raise RuntimeError(f"MCP request failed: {message}")
+
+        return response["result"]
+
+    async def _send_notification(self, payload: JsonDict) -> None:
+        await self._write_json(payload)
+
+    async def _write_json(self, payload: JsonDict) -> None:
+        assert self._process and self._process.stdin
+        message = json.dumps(payload, separators=(",", ":")) + "\n"
+        self._process.stdin.write(message.encode("utf-8"))
+        await self._process.stdin.drain()
+
+    async def _read_stdout(self, stream: asyncio.StreamReader) -> None:
+        while True:
+            line = await stream.readline()
+            if not line:
+                break
+            message = json.loads(line.decode("utf-8"))
+            await self._handle_server_message(message)
+
+    async def _log_stderr(self, stream: asyncio.StreamReader) -> None:
+        while True:
+            line = await stream.readline()
+            if not line:
+                break
+            sys.stderr.write(line.decode("utf-8"))
+            sys.stderr.flush()
+
+    async def _handle_server_message(self, message: JsonDict) -> None:
+        if "id" in message and "result" in message:
+            await self._resolve_pending(message)
+        elif "id" in message and "error" in message:
+            await self._resolve_pending(message)
+        elif "id" in message and "method" in message:
+            await self._handle_server_request(message)
+        elif "method" in message:
+            # Notification from server – log it so the user can see what's happening.
+            params = message.get("params", {})
+            print(f"[notification] {message['method']}: {params}")
+        else:
+            print(f"[unknown message] {message}")
+
+    async def _resolve_pending(self, message: JsonDict) -> None:
+        request_id = message["id"]
+        pending = self._pending.pop(request_id, None)
+        if pending:
+            pending.future.set_result(message)
+
+    async def _handle_server_request(self, message: JsonDict) -> None:
+        method = message["method"]
+        request_id = message["id"]
+
+        if method == "roots/list":
+            response = {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {"roots": []},
+            }
+        elif method == "ping":
+            response = {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {},
+            }
+        else:
+            response = {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {
+                    "code": -32601,
+                    "message": f"Client does not implement {method}",
+                },
+            }
+
+        await self._write_json(response)
+
+    def _next_id(self) -> int:
+        request_id = self._next_request_id
+        self._next_request_id += 1
+        return request_id
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Minimal MCP client for mcp-server-git")
+    parser.add_argument(
+        "--repository",
+        "-r",
+        type=Path,
+        default=Path.cwd(),
+        help="Git repository path to expose to the MCP server",
+    )
+    parser.add_argument(
+        "--tool",
+        default="git_status",
+        help="Tool name to call after listing the available tools",
+    )
+    parser.add_argument(
+        "--args",
+        nargs="*",
+        default=None,
+        help="Optional JSON arguments for the tool call (key=value pairs)",
+    )
+    return parser
+
+
+def parse_tool_arguments(arguments: list[str] | None) -> JsonDict:
+    if not arguments:
+        return {}
+
+    parsed: JsonDict = {}
+    for item in arguments:
+        if "=" not in item:
+            raise ValueError(f"Invalid argument '{item}', expected key=value")
+        key, value = item.split("=", 1)
+        try:
+            parsed[key] = json.loads(value)
+        except json.JSONDecodeError:
+            parsed[key] = value
+    return parsed
+
+
+async def demo(tool_name: str, repository: Path, tool_arguments: JsonDict | None = None) -> None:
+    async with MCPGitClient(repository=repository) as client:
+        tools: list[JsonDict] = []
+        cursor: str | None = None
+        while True:
+            result = await client.list_tools(cursor)
+            tools.extend(result.get("tools", []))
+            cursor = result.get("nextCursor")
+            if not cursor:
+                break
+
+        print("Available tools:")
+        for tool in tools:
+            description = tool.get("description", "")
+            print(f"  - {tool['name']}: {description}")
+
+        arguments = {"repo_path": str(repository)}
+        if tool_arguments:
+            arguments.update(tool_arguments)
+
+        result = await client.call_tool(tool_name, arguments=arguments)
+        print("\nTool response:")
+        content_blocks = result.get("content", [])
+        if content_blocks:
+            for block in content_blocks:
+                block_type = block.get("type")
+                if block_type == "text":
+                    print(block.get("text", ""))
+                else:
+                    print(json.dumps(block, indent=2))
+        elif "structuredContent" in result:
+            print(json.dumps(result["structuredContent"], indent=2))
+        else:
+            print(json.dumps(result, indent=2))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_argument_parser()
+    args = parser.parse_args(argv)
+
+    tool_arguments = parse_tool_arguments(args.args)
+
+    try:
+        asyncio.run(demo(args.tool, args.repository, tool_arguments))
+    except KeyboardInterrupt:
+        return 1
+    except Exception as exc:  # noqa: BLE001 - display readable error to users
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/kinyu/mcp/git.py
+++ b/src/kinyu/mcp/git.py
@@ -1,9 +1,10 @@
-"""Example MCP client that talks to ``mcp-server-git`` without third-party deps.
+"""Example MCP client that talks to an arbitrary MCP server.
 
 The goal of this module is to demonstrate the minimum plumbing that a Python
 program needs in order to communicate with an MCP server using only the
-standard library.  It follows the JSON-RPC interface that the
-``mcp-server-git`` package exposes over stdio.
+standard library.  It follows the JSON-RPC interface that MCP servers expose
+over stdio.  The included CLI showcases the ``mcp-server-git`` configuration,
+but the ``MCPClient`` class itself is agnostic to the server it launches.
 
 Usage
 -----
@@ -17,7 +18,7 @@ The script will:
   ``MCP_CONFIG`` constant,
 * perform the JSON-RPC handshake (`initialize` followed by
   ``notifications/initialized``),
-* list the Git-related tools that the server exposes, and
+* list the tools that the server exposes, and
 * call ``git_status`` as a concrete example.
 
 Because the transport uses newline-delimited JSON, the implementation below
@@ -46,7 +47,7 @@ MCP_CONFIG: JsonDict = {
         }
     }
 }
-"""Model Context Protocol configuration for the git server."""
+"""Demonstration Model Context Protocol configuration."""
 
 
 @dataclass
@@ -57,11 +58,12 @@ class PendingRequest:
 
 
 @dataclass
-class MCPGitClient:
-    """Minimal asynchronous MCP client that talks to ``mcp-server-git``."""
+class MCPClient:
+    """Minimal asynchronous MCP client that can launch any configured server."""
 
-    repository: Path
+    server_name: str = "git"
     config: JsonDict = field(default_factory=lambda: json.loads(json.dumps(MCP_CONFIG)))
+    server_args: list[str] = field(default_factory=list)
     _process: Process | None = field(default=None, init=False, repr=False)
     _stdout_task: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
     _stderr_task: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
@@ -69,7 +71,7 @@ class MCPGitClient:
     _next_request_id: int = field(default=1, init=False, repr=False)
     _loop: asyncio.AbstractEventLoop | None = field(default=None, init=False, repr=False)
 
-    async def __aenter__(self) -> "MCPGitClient":
+    async def __aenter__(self) -> "MCPClient":
         await self._start()
         return self
 
@@ -77,14 +79,12 @@ class MCPGitClient:
         await self.close()
 
     async def _start(self) -> None:
-        """Launch the ``mcp-server-git`` subprocess and set up background tasks."""
+        """Launch the configured MCP server subprocess and set up background tasks."""
 
-        server_cfg = self.config["servers"]["git"]
+        server_cfg = self.config["servers"][self.server_name]
         command = server_cfg["command"]
         args = list(server_cfg.get("args", []))
-
-        # ``mcp-server-git`` accepts a ``--repository`` CLI argument.
-        args.extend(["--repository", str(self.repository)])
+        args.extend(self.server_args)
 
         self._loop = asyncio.get_running_loop()
 
@@ -153,7 +153,7 @@ class MCPGitClient:
         )
 
     async def list_tools(self, cursor: str | None = None) -> JsonDict:
-        """Return the list of tools exposed by ``mcp-server-git``."""
+        """Return the list of tools exposed by the connected server."""
 
         request_id = self._next_id()
         request = {
@@ -278,13 +278,33 @@ class MCPGitClient:
 
 
 def build_argument_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Minimal MCP client for mcp-server-git")
+    parser = argparse.ArgumentParser(
+        description=(
+            "Minimal MCP client example that can launch servers defined in the"
+            " provided configuration."
+        )
+    )
+    parser.add_argument(
+        "--server-name",
+        default="git",
+        help="Identifier of the server to launch from the MCP configuration",
+    )
+    parser.add_argument(
+        "--server-arg",
+        action="append",
+        dest="server_args",
+        default=None,
+        help="Additional CLI arguments for the server command (repeatable)",
+    )
     parser.add_argument(
         "--repository",
         "-r",
         type=Path,
-        default=Path.cwd(),
-        help="Git repository path to expose to the MCP server",
+        default=None,
+        help=(
+            "Convenience flag for the git demo: append --repository <path> when"
+            " launching the server"
+        ),
     )
     parser.add_argument(
         "--tool",
@@ -316,8 +336,21 @@ def parse_tool_arguments(arguments: list[str] | None) -> JsonDict:
     return parsed
 
 
-async def demo(tool_name: str, repository: Path, tool_arguments: JsonDict | None = None) -> None:
-    async with MCPGitClient(repository=repository) as client:
+async def demo(
+    tool_name: str,
+    server_name: str,
+    tool_arguments: JsonDict | None = None,
+    *,
+    server_args: list[str] | None = None,
+    config: JsonDict | None = None,
+) -> None:
+    source_config = config if config is not None else MCP_CONFIG
+    client_config = json.loads(json.dumps(source_config))
+    async with MCPClient(
+        server_name=server_name,
+        server_args=list(server_args or []),
+        config=client_config,
+    ) as client:
         tools: list[JsonDict] = []
         cursor: str | None = None
         while True:
@@ -332,11 +365,7 @@ async def demo(tool_name: str, repository: Path, tool_arguments: JsonDict | None
             description = tool.get("description", "")
             print(f"  - {tool['name']}: {description}")
 
-        arguments = {"repo_path": str(repository)}
-        if tool_arguments:
-            arguments.update(tool_arguments)
-
-        result = await client.call_tool(tool_name, arguments=arguments)
+        result = await client.call_tool(tool_name, arguments=tool_arguments or {})
         print("\nTool response:")
         content_blocks = result.get("content", [])
         if content_blocks:
@@ -358,8 +387,32 @@ def main(argv: list[str] | None = None) -> int:
 
     tool_arguments = parse_tool_arguments(args.args)
 
+    server_args = list(args.server_args or [])
+
+    repo_for_tool: Path | None = None
+
+    if args.repository is not None:
+        server_args.extend(["--repository", str(args.repository)])
+        repo_for_tool = args.repository
+
+    if args.server_name == "git":
+        if repo_for_tool is None:
+            repo_for_tool = Path.cwd()
+            if "--repository" not in server_args and "-r" not in server_args:
+                server_args.extend(["--repository", str(repo_for_tool)])
+
+        if "repo_path" not in tool_arguments and repo_for_tool is not None:
+            tool_arguments["repo_path"] = str(repo_for_tool)
+
     try:
-        asyncio.run(demo(args.tool, args.repository, tool_arguments))
+        asyncio.run(
+            demo(
+                args.tool,
+                args.server_name,
+                tool_arguments,
+                server_args=server_args,
+            )
+        )
     except KeyboardInterrupt:
         return 1
     except Exception as exc:  # noqa: BLE001 - display readable error to users


### PR DESCRIPTION
## Summary
- add a new `kinyu.mcp` package with documentation for the MCP git demo
- implement an asynchronous JSON-RPC client that launches `mcp-server-git` using only the Python standard library
- provide a CLI entry point that lists tools and calls one of them against a chosen repository

## Testing
- PYTHONPATH=src python -m kinyu.mcp.git --repository . --tool git_status

------
https://chatgpt.com/codex/tasks/task_e_68e4d9880b948321b5d0994799642a55